### PR TITLE
String Decoder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,19 +57,23 @@ gulp.task('bench', () => {
         let contents = util.multiplyLines(file.contents, 10);
         let res1 = util.average(contents, 10, false);
         let res2 = util.average(contents, 10, true);
+        let count = contents.match(/"|,|\r\n|\n/g).length;
+        let density = util.number(count/contents.length);
 
         return[{
             file: file,
             rows: res1.rows,
             ms: res1.ms,
             bytes: Buffer.byteLength(contents),
-            mode: 'string'
+            mode: 'string',
+            density
         }, {
             file: file,
             rows: res2.rows,
             ms: res2.ms,
             bytes: Buffer.byteLength(contents),
-            mode: 'buffer'
+            mode: 'buffer',
+            density
         }];
 
     }).map(res => {
@@ -79,6 +83,7 @@ gulp.task('bench', () => {
         _.map(res, test => {
             t.cell('Filename', test.file.name);
             t.cell('Mode', test.mode);
+            t.cell('Density', test.density);
             t.cell('Rows', util.number(test.rows));
             t.cell('Bytes', util.number(test.bytes));
             t.cell('Time (ms)', util.number(test.ms));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,21 +55,30 @@ gulp.task('bench', () => {
     return pw.contents('./tests/data/Earthquakes.csv', { src: '**/*.csv' }).map(file => {
 
         let contents = util.multiplyLines(file.contents, 10);
-        let res = util.average(contents, 10);
+        let res1 = util.average(contents, 10, false);
+        let res2 = util.average(contents, 10, true);
 
-        return({
+        return[{
             file: file,
-            rows: res.rows,
-            ms: res.ms,
-            bytes: Buffer.byteLength(contents)
-        });
+            rows: res1.rows,
+            ms: res1.ms,
+            bytes: Buffer.byteLength(contents),
+            mode: 'string'
+        }, {
+            file: file,
+            rows: res2.rows,
+            ms: res2.ms,
+            bytes: Buffer.byteLength(contents),
+            mode: 'buffer'
+        }];
 
-    }).then(res => {
+    }).map(res => {
 
         let t = new Table();
 
         _.map(res, test => {
             t.cell('Filename', test.file.name);
+            t.cell('Mode', test.mode);
             t.cell('Rows', util.number(test.rows));
             t.cell('Bytes', util.number(test.bytes));
             t.cell('Time (ms)', util.number(test.ms));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,19 @@ gulp.task('test-parse', () => {
 
 });
 
+gulp.task('test-buffer', () => {
+
+    return util.getCSVData().then(data => {
+
+        let start = process.hrtime();
+        let res = CSV.parse(data.buff);
+
+        util.stats(util.ms(start), res.length, Buffer.byteLength(data.str));
+
+    });
+
+});
+
 gulp.task('bench', () => {
 
     return pw.contents('./tests/data/Earthquakes.csv', { src: '**/*.csv' }).map(file => {

--- a/index.js
+++ b/index.js
@@ -219,23 +219,6 @@ class CsvParser {
         this._nextIndex = -1;
         this._nextChar = '';
 
-        // while (this._match() > -1) {
-
-        //     switch (this._nextChar) {
-        //         case this.delimeter:
-        //             this._handleDelimeter(this._nextIndex, this._nextChar);
-        //             break;
-        //         case this.quote:
-        //             this._handleQuote(this._nextIndex, this._nextChar);
-        //             break;
-        //         case this.newline:
-        //             this._handleNewline(this._nextIndex, this._nextChar);
-        //             break;
-        //     }
-
-        // }
-
-
 
         if (this.offset < this.str.length - 1) {
             this.str = this.str.slice(this.offset);

--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ class CsvParser {
         this._nextIndex = -1;
         this._nextChar = '';
 
+        this.regex = new RegExp(`${opts.delimeter}|${opts.quote}|${opts.newline}`, 'g');
+
     }
 
     _flushValue () {
@@ -184,6 +186,8 @@ class CsvParser {
 
     parse (str) {
 
+        let match;
+
         // handle buffers and strings
         if (this.opts.buffer) {
             this.str += this.decoder.write(str);
@@ -191,21 +195,47 @@ class CsvParser {
             this.str += str;
         }
 
-        while (this._match() > -1) {
+        while ((match = this.regex.exec(this.str)) !== null) {
 
-            switch (this._nextChar) {
+            this._prevChar = this._nextChar;
+            this._prevIndex = this._nextIndex;
+            this._nextChar = match[0];
+            this._nextIndex = match.index;
+
+            switch (match[0]) {
                 case this.delimeter:
-                    this._handleDelimeter(this._nextIndex, this._nextChar);
+                    this._handleDelimeter(match.index, match[0]);
                     break;
                 case this.quote:
-                    this._handleQuote(this._nextIndex, this._nextChar);
+                    this._handleQuote(match.index, match[0]);
                     break;
                 case this.newline:
-                    this._handleNewline(this._nextIndex, this._nextChar);
+                    this._handleNewline(match.index, match[0]);
                     break;
             }
 
         }
+
+        this._nextIndex = -1;
+        this._nextChar = '';
+
+        // while (this._match() > -1) {
+
+        //     switch (this._nextChar) {
+        //         case this.delimeter:
+        //             this._handleDelimeter(this._nextIndex, this._nextChar);
+        //             break;
+        //         case this.quote:
+        //             this._handleQuote(this._nextIndex, this._nextChar);
+        //             break;
+        //         case this.newline:
+        //             this._handleNewline(this._nextIndex, this._nextChar);
+        //             break;
+        //     }
+
+        // }
+
+
 
         if (this.offset < this.str.length - 1) {
             this.str = this.str.slice(this.offset);

--- a/lib/util.js
+++ b/lib/util.js
@@ -134,12 +134,13 @@ function stats (ms, rows, bytes) {
     console.log('Finished:', number(ms), 'ms', '|', number(rows), 'rows', '|', number(bytes), 'bytes', '|', number(bps(ms, bytes)), 'bytes per second', '|', number(rps(ms, rows)), 'rows per second');
 }
 
-function average (str, count) {
+function average (str, count, buffer) {
 
     let time = [];
     let rows = [];
 
     count = count || 10;
+    str = buffer ? Buffer.from(str) : str;
 
     for (let i = 0; i < count; i++) {
         let start = process.hrtime();

--- a/lib/util.js
+++ b/lib/util.js
@@ -107,7 +107,8 @@ function getCSVData () {
     return getCSVContents().then(str => {
         str = multiplyLines(str, 10);
         let stream = new ReadStream(str);
-        return { stream, str };
+        let buff = Buffer.from(str);
+        return { stream, str, buff };
     });
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,7 +1733,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1754,12 +1755,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1774,17 +1777,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1901,7 +1907,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1913,6 +1920,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1927,6 +1935,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1934,12 +1943,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1958,6 +1969,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2038,7 +2050,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2050,6 +2063,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2135,7 +2149,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2171,6 +2186,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2190,6 +2206,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2233,12 +2250,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Uses `string_decoder` to parse buffers, vastly improves performance. Removes `indexOf` parser and replaces with `regex.exec` for more consistent performance across various densities. Overall performance has been greatly improved and code is simplified. Updated docs and benchmarks.